### PR TITLE
Improve gallery image layout

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -473,3 +473,25 @@ body.ready { opacity: 1; }
 .model-loader{position:absolute;top:50%;left:50%;width:32px;height:32px;margin:-16px 0 0 -16px;border:4px solid #ccc;border-top-color:var(--rpg-gold-light);border-radius:50%;animation:spin .8s linear infinite}
 @keyframes spin{to{transform:rotate(360deg)}}
 
+/* ===== Responsive Image Wrappers ===== */
+.image-wrapper{
+  position:relative;
+  width:100%;
+  aspect-ratio:4/3;
+  overflow:hidden;
+  display:flex;
+  justify-content:center;
+  align-items:center;
+  background-color:#f9f9f9;
+}
+.image-wrapper img{
+  max-width:100%;
+  max-height:100%;
+  object-fit:contain;
+  object-position:center;
+  display:block;
+}
+@media screen and (max-width:768px){
+  .image-wrapper{aspect-ratio:3/4;}
+}
+

--- a/index.html
+++ b/index.html
@@ -61,10 +61,26 @@ description: "Birthday celebration page"
     <h2 class="mb-4">Gallery</h2>
      <p class="mb-4">A few of my favorite moments with you:</p>
     <div class="row g-3">
-      <div class="col-6 col-md-3"><img src="assets/images/gallery_mcdonalds_smile.jpg" class="img-fluid" alt="Klerissa at McDonald's (my favorite photo)" loading="lazy"></div>
-      <div class="col-6 col-md-3"><img src="assets/images/gallery_us_tokyo.png" class="img-fluid" alt="Together in Tokyo – dream trip!" loading="lazy"></div>
-      <div class="col-6 col-md-3"><img src="assets/images/gallery_first_date.png" class="img-fluid" alt="On our first date, April 2025" loading="lazy"></div>
-      <div class="col-6 col-md-3"><img src="assets/images/gallery_silly_selfie.jpg" class="img-fluid" alt="A silly selfie of us 😂" loading="lazy"></div>
+      <div class="col-6 col-md-3">
+        <div class="image-wrapper">
+          <img src="assets/images/gallery_mcdonalds_smile.jpg" class="img-fluid" alt="Klerissa at McDonald's (my favorite photo)" loading="lazy">
+        </div>
+      </div>
+      <div class="col-6 col-md-3">
+        <div class="image-wrapper">
+          <img src="assets/images/gallery_us_tokyo.png" class="img-fluid" alt="Together in Tokyo – dream trip!" loading="lazy">
+        </div>
+      </div>
+      <div class="col-6 col-md-3">
+        <div class="image-wrapper">
+          <img src="assets/images/gallery_first_date.png" class="img-fluid" alt="On our first date, April 2025" loading="lazy">
+        </div>
+      </div>
+      <div class="col-6 col-md-3">
+        <div class="image-wrapper">
+          <img src="assets/images/gallery_silly_selfie.jpg" class="img-fluid" alt="A silly selfie of us 😂" loading="lazy">
+        </div>
+      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- wrap gallery images in new `.image-wrapper` containers
- add responsive CSS to keep portrait images contained

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_687c20b40dac8333a4df8d71e31f438d